### PR TITLE
Add skip_serializing_if field attr

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -40,5 +40,6 @@ pub struct Tag {
     pub region: String,
     pub instance_id: String,
     pub canary: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub load_balancing_weight: Option<u8>,
 }


### PR DESCRIPTION
follow up https://github.com/cookpad/sds/pull/2

skip_serializing_if: https://serde.rs/field-attrs.html#serdeskipserializingif--path

Returning the value of `load_balancing_weight` as `null` is not
acceptable for envoy. it's only acceptable number(1-100) or nothing.
https://www.envoyproxy.io/docs/envoy/latest/api-v1/cluster_manager/sds#host-json


@cookpad/dev-infra review please 🙏 
