### PR TITLE
Keep AWS session as much as possible

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,10 +20,12 @@ fn main() {
         parse_uint(v)
     };
     let table_name = fetch_env_var("DDB_TABLE");
+    let dynamodb_client = rusoto_dynamodb::DynamoDbClient::new(Default::default());
 
-    let storage: StorageImpl = StorageImpl {
+    let storage = StorageImpl {
         table_name: table_name,
         ttl: ttl,
+        dynamodb_client: dynamodb_client,
     };
     let c = Config {
         listen_port: listen_port,


### PR DESCRIPTION
Fetching session credentials from ECS task role or EC2 instance profile
is run each time DynamoDB API is called. This is very fragile because
the session credentials endpoint could fail.

@cookpad/infra could you review this?