### PR TITLE
Add revision/task_arn field to v2 eds

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -21,7 +21,7 @@ use super::v2xds::{
     EDS_TYPE_URL,
 };
 
-type BoxFut = Box<Future<Item = Response<Body>, Error = hyper::Error> + Send>;
+type BoxFut = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct RegistrationParam {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -28,7 +28,7 @@ impl fmt::Display for StorageError {
 }
 
 impl error::Error for StorageError {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         // TODO
         None
     }

--- a/src/v2xds.rs
+++ b/src/v2xds.rs
@@ -89,6 +89,7 @@ pub struct Metadata {
 pub struct LbFilterMetadata {
     pub canary: bool,
     pub revision: String,
+    pub instance_id: String,
 }
 
 pub fn hosts_to_locality_lb_endpoints(mut hosts: Vec<Host>) -> Vec<LocalityLbEndpoints> {
@@ -127,6 +128,7 @@ fn convert_host_to_le(h: Host) -> LbEndpoint {
         LbFilterMetadata {
             canary: h.tags.canary,
             revision: h.revision,
+            instance_id: h.tags.instance_id,
         },
     );
 

--- a/src/v2xds.rs
+++ b/src/v2xds.rs
@@ -88,6 +88,7 @@ pub struct Metadata {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct LbFilterMetadata {
     pub canary: bool,
+    pub revision: String,
 }
 
 pub fn hosts_to_locality_lb_endpoints(mut hosts: Vec<Host>) -> Vec<LocalityLbEndpoints> {
@@ -125,6 +126,7 @@ fn convert_host_to_le(h: Host) -> LbEndpoint {
         "envoy.lb".to_owned(),
         LbFilterMetadata {
             canary: h.tags.canary,
+            revision: h.revision,
         },
     );
 


### PR DESCRIPTION
Add tag/revision field in v1 SDS to metadata in v2 EDS.

I confirmed this change works on my local envoy.

@cookpad/infra please review.